### PR TITLE
[plasma-store] publish to crates.io

### DIFF
--- a/plasma-store/Cargo.toml
+++ b/plasma-store/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["François Garillot <fga@fb.com>", "Irakliy Khaburzaniya <irakliyk@fb
 description = "Rust bindings for Arrow Plasma object store"
 keywords = [ "arrow", "plasma" ]
 categories = [ "no-std",  "api-bindings" ]
-repository = "https://github.com/facebookresearch/rust-plasma"
+repository = "https://github.com/novifinancial/rust-plasma"
+readme = "README.md"
 license = "MIT"
 edition = "2018"
 
@@ -16,7 +17,7 @@ bench = false
 cxx = "1.0"
 libc = "0.2"
 rand = "0.8"
-thiserror = "1"
+thiserror = "1.0"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
This PR will prepare `plasma-store` crate for publishing to crates.io. I believe the tasks are:

- [ ] Add rust-style comments to describe the crate
- [ ] Generate documentation
- [ ] Get credentials for publishing

Anything else?