### PR TITLE
Fix unsound get_buffer_data signatures

### DIFF
--- a/plasma-store/src/ffi/ffi.cc
+++ b/plasma-store/src/ffi/ffi.cc
@@ -41,13 +41,13 @@ namespace plasma {
     return std::make_unique<ObjectBuffer>(ObjectBuffer{data_ptr, metadata_ptr, 0});
   }
 
-  rust::Slice<const unsigned char> get_buffer_data(std::shared_ptr<Buffer> buffer) {
+  rust::Slice<const unsigned char> get_buffer_data(const std::shared_ptr<Buffer>& buffer) {
     const uint8_t *c = buffer->data();
     int64_t len = buffer->size();
     return rust::Slice<const unsigned char>(c, len);
   }
 
-  rust::Slice<unsigned char> get_buffer_data_mut(std::shared_ptr<Buffer> buffer) {
+  rust::Slice<unsigned char> get_buffer_data_mut(const std::shared_ptr<Buffer>& buffer) {
     uint8_t *c = buffer->mutable_data();
     int64_t len = buffer->size();
     return rust::Slice<unsigned char>(c, len);

--- a/plasma-store/src/ffi/ffi.h
+++ b/plasma-store/src/ffi/ffi.h
@@ -29,9 +29,9 @@ namespace plasma {
 
   std::unique_ptr<ObjectBuffer> new_obj_buffer();
 
-  rust::Slice<const unsigned char> get_buffer_data(std::shared_ptr<Buffer> buffer);
+  rust::Slice<const unsigned char> get_buffer_data(const std::shared_ptr<Buffer>& buffer);
   
-  rust::Slice<unsigned char> get_buffer_data_mut(std::shared_ptr<Buffer> buffer);
+  rust::Slice<unsigned char> get_buffer_data_mut(const std::shared_ptr<Buffer>& buffer);
 
   //////////////////
   // PlasmaClient //

--- a/plasma-store/src/ffi/mod.rs
+++ b/plasma-store/src/ffi/mod.rs
@@ -59,8 +59,15 @@ pub mod ffi {
         #[namespace = "arrow"]
         type Buffer;
 
-        fn get_buffer_data<'a>(buffer: SharedPtr<Buffer>) -> &'a [u8];
-        fn get_buffer_data_mut<'a>(buffer: SharedPtr<Buffer>) -> &'a mut [u8];
+        // Safety:
+        //   - caller must not retain slice past the destruction of the buffer
+        unsafe fn get_buffer_data<'a>(buffer: SharedPtr<Buffer>) -> &'a [u8];
+
+        // Safety:
+        //   - buffer must be a mutable CPU buffer
+        //   - caller must not retain slice past the destruction of the buffer
+        //   - caller must not obtain overlapping slices of the same buffer
+        unsafe fn get_buffer_data_mut<'a>(buffer: SharedPtr<Buffer>) -> &'a mut [u8];
 
         #[namespace = "arrow"]
         type MutableBuffer;

--- a/plasma-store/src/ffi/mod.rs
+++ b/plasma-store/src/ffi/mod.rs
@@ -59,15 +59,12 @@ pub mod ffi {
         #[namespace = "arrow"]
         type Buffer;
 
-        // Safety:
-        //   - caller must not retain slice past the destruction of the buffer
-        unsafe fn get_buffer_data<'a>(buffer: SharedPtr<Buffer>) -> &'a [u8];
+        fn get_buffer_data(buffer: &SharedPtr<Buffer>) -> &[u8];
 
         // Safety:
         //   - buffer must be a mutable CPU buffer
-        //   - caller must not retain slice past the destruction of the buffer
         //   - caller must not obtain overlapping slices of the same buffer
-        unsafe fn get_buffer_data_mut<'a>(buffer: SharedPtr<Buffer>) -> &'a mut [u8];
+        unsafe fn get_buffer_data_mut(buffer: &SharedPtr<Buffer>) -> &mut [u8];
 
         #[namespace = "arrow"]
         type MutableBuffer;

--- a/plasma-store/src/ffi/tests.rs
+++ b/plasma-store/src/ffi/tests.rs
@@ -91,7 +91,7 @@ fn plasma_ffi_create() {
         let meta = vec![1, 3, 5, 7];
         let res2 = ffi::create(pc, ob.pin_mut(), &oid, 8, &meta);
 
-        let data_mut = ffi::get_buffer_data_mut(ob.data.clone());
+        let data_mut = unsafe { ffi::get_buffer_data_mut(ob.data.clone()) };
         for i in 0..8 {
             data_mut[i] = i as u8;
         }

--- a/plasma-store/src/ffi/tests.rs
+++ b/plasma-store/src/ffi/tests.rs
@@ -91,7 +91,7 @@ fn plasma_ffi_create() {
         let meta = vec![1, 3, 5, 7];
         let res2 = ffi::create(pc, ob.pin_mut(), &oid, 8, &meta);
 
-        let data_mut = unsafe { ffi::get_buffer_data_mut(ob.data.clone()) };
+        let data_mut = unsafe { ffi::get_buffer_data_mut(&ob.data) };
         for i in 0..8 {
             data_mut[i] = i as u8;
         }

--- a/plasma-store/src/lib.rs
+++ b/plasma-store/src/lib.rs
@@ -119,25 +119,25 @@ impl<'a> ObjectBuffer<'a> {
 
     /// Returns read-only data buffer of this object buffer.
     pub fn data(&self) -> &[u8] {
-        unsafe { plasma::get_buffer_data(self.buf.data.clone()) }
+        plasma::get_buffer_data(&self.buf.data)
     }
 
     /// Returns mutable data buffer of this object buffer.
     pub fn data_mut(&mut self) -> &mut [u8] {
         assert!(self.is_mutable, "object buffer is not mutable");
-        unsafe { plasma::get_buffer_data_mut(self.buf.data.clone()) }
+        unsafe { plasma::get_buffer_data_mut(&self.buf.data) }
     }
 
     /// Returns metadata buffer of this object buffer.
     pub fn meta(&self) -> &[u8] {
-        unsafe { plasma::get_buffer_data(self.buf.metadata.clone()) }
+        plasma::get_buffer_data(&self.buf.metadata)
     }
 
     /// Returns the size of this object buffer in bytes; this includes size of data and
     /// metadata.
     pub fn size(&self) -> usize {
-        let meta_size = unsafe { plasma::get_buffer_data(self.buf.metadata.clone()) }.len();
-        let data_size = unsafe { plasma::get_buffer_data(self.buf.data.clone()) }.len();
+        let meta_size = plasma::get_buffer_data(&self.buf.metadata).len();
+        let data_size = plasma::get_buffer_data(&self.buf.data).len();
         meta_size + data_size
     }
 

--- a/plasma-store/src/lib.rs
+++ b/plasma-store/src/lib.rs
@@ -119,25 +119,25 @@ impl<'a> ObjectBuffer<'a> {
 
     /// Returns read-only data buffer of this object buffer.
     pub fn data(&self) -> &[u8] {
-        plasma::get_buffer_data(self.buf.data.clone())
+        unsafe { plasma::get_buffer_data(self.buf.data.clone()) }
     }
 
     /// Returns mutable data buffer of this object buffer.
     pub fn data_mut(&mut self) -> &mut [u8] {
         assert!(self.is_mutable, "object buffer is not mutable");
-        plasma::get_buffer_data_mut(self.buf.data.clone())
+        unsafe { plasma::get_buffer_data_mut(self.buf.data.clone()) }
     }
 
     /// Returns metadata buffer of this object buffer.
     pub fn meta(&self) -> &[u8] {
-        plasma::get_buffer_data(self.buf.metadata.clone())
+        unsafe { plasma::get_buffer_data(self.buf.metadata.clone()) }
     }
 
     /// Returns the size of this object buffer in bytes; this includes size of data and
     /// metadata.
     pub fn size(&self) -> usize {
-        let meta_size = plasma::get_buffer_data(self.buf.metadata.clone()).len();
-        let data_size = plasma::get_buffer_data(self.buf.data.clone()).len();
+        let meta_size = unsafe { plasma::get_buffer_data(self.buf.metadata.clone()) }.len();
+        let data_size = unsafe { plasma::get_buffer_data(self.buf.data.clone()) }.len();
         meta_size + data_size
     }
 


### PR DESCRIPTION
The way `get_buffer_data` and `get_buffer_data_mut` were exposed to Rust is unsafe for 3 reasons. It's unsound to expose those behaviors as safe-to-call to Rust.

1. If the caller passes a non-mutable slice to get_buffer_data_mut, the implementation ends up creating a rust::Slice with a null data ptr, which is UB.

2. The lifetime of the output reference is totally unconstrained. The caller is responsible for not retaining a reference to the slice beyond when the underlying buffer is destroyed, which would be UB.

3. Obtaining multiple overlapping mutable slices is UB. A caller could just call get_buffer_data_mut twice with clones of the same SharedPtr and thereby end up with overlapping slices.

The first commit makes both methods unsafe-to-call with documentation of the reasons above.

The second commit resolves reason 2 by attaching the lifetime of the output reference to the SharedPtr it originates from.

@irakliyk