### PR TITLE
Resolve inconsistent_struct_constructor clippy lint to unblock CI

### DIFF
--- a/plasma-stream/src/server/listener.rs
+++ b/plasma-stream/src/server/listener.rs
@@ -53,8 +53,8 @@ impl Listener {
 
         Ok(Listener {
             listener,
-            limit_connections,
             store,
+            limit_connections,
         })
     }
 


### PR DESCRIPTION
The CI build on #3 is failing for reasons unrelated to that PR. This fixes that error.

```console
error: struct constructor field order is inconsistent with struct definition field order
  --> plasma-stream/src/server/listener.rs:54:12
   |
54 |           Ok(Listener {
   |  ____________^
55 | |             listener,
56 | |             limit_connections,
57 | |             store,
58 | |         })
   | |_________^ help: try: `Listener { listener, store, limit_connections }`
   |
   = note: `-D clippy::inconsistent-struct-constructor` implied by `-D clippy::all`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#inconsistent_struct_constructor
```

@irakliyk