### PR TITLE
Visibility of ffi module

### DIFF
--- a/plasma-store/src/ffi/mod.rs
+++ b/plasma-store/src/ffi/mod.rs
@@ -8,7 +8,7 @@ mod tests;
 
 #[allow(clippy::all)]
 #[cxx::bridge(namespace = plasma)]
-pub mod ffi {
+pub(crate) mod ffi {
 
     /// Object buffer data structure.
     struct ObjectBuffer {


### PR DESCRIPTION
This PR changes visibility of ffi module from `pub` to `pub(crate)`.